### PR TITLE
Add benchmark and profiling for cvaluate.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ endif()
 # Global CMake options.
 option(CVALUATE_INSTALL "State whether to install cavaluate" ON)
 option(CVALUATE_BUILD_TEST "State whether to build test" ON)
+option(CVALUATE_BUILD_BENCHMARK "State whether to build benchmark" ON)
 
 # Intrinsic directory paths
 set(CVALUATE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cvaluate)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ option(CVALUATE_BUILD_BENCHMARK "State whether to build benchmark" ON)
 # Intrinsic directory paths
 set(CVALUATE_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/cvaluate)
 set(CVALUATE_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-set(CVALUATE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include/cvaluate)
+set(CVALUATE_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 # Do not output install messages.
 if(NOT DEFINED CMAKE_INSTALL_MESSAGE)

--- a/Readme.md
+++ b/Readme.md
@@ -18,19 +18,19 @@ Provides support for evaluating arbitrary C-like artithmetic/string expressions 
 - [x] Build expression tree by tokens.
     - [x] Support baisc numeric add expression `1 + 49`.
     - [x] Design  expression tree like [evaluationStage](https://github.com/Knetic/govaluate/blob/master/evaluationStage.go).
-    - [ ] Test expression tree.
+    - [x] Test expression tree.
 - [x] Support basic math expression.
     - [x] Support `+-*/`.
     - [x] Support compare operator.
     - [x] If two operator have same prority, like `"1 + 101 % 2 * 5"`. Because `2 * 5` is in the right stage of operator `%`, so it will calculate `2 * 5` first. In this case, we will get wrong answer `2` rather than `6`. This issue can be fixed by [reorderStages](https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/stagePlanner.go#L556).
     - [ ] Support bit shift.  
-- [ ] Support variable and accessors.
+- [x] Support variable and accessors.
     - [x] Support `Eval(params)`, `params` is a `map` like `name: object` in `gvaluate `.
     - [x] ~~Basic data type of `params` is `int ,float, string`.~~ Use [json](https://github.com/nlohmann/json) as base data type.
     - [x] Support simple field accessor using json.
     - [x] Object data of `params` should reload `operator[]` and `operator` for `access` and compare. Maybe we can accomplish it by define a base object or use template to support accessors.
 
-- [ ] Add benchmark for Cvaluate.
+- [x] Add benchmark for Cvaluate.
 - [ ] Performance enhancement.
 
 ## Install Cvaluate

--- a/Readme.md
+++ b/Readme.md
@@ -22,16 +22,16 @@ Provides support for evaluating arbitrary C-like artithmetic/string expressions 
 - [x] Support basic math expression.
     - [x] Support `+-*/`.
     - [x] Support compare operator.
-    - [ ] If two operator have same prority, like `"1 + 101 % 2 * 5"`. Because `2 * 5` is in the right stage of operator `%`, so it will calculate `2 * 5` first. In this case, we will get wrong answer `2` rather than `6`. This issue can be fixed by [reorderStages](https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/stagePlanner.go#L556).
+    - [x] If two operator have same prority, like `"1 + 101 % 2 * 5"`. Because `2 * 5` is in the right stage of operator `%`, so it will calculate `2 * 5` first. In this case, we will get wrong answer `2` rather than `6`. This issue can be fixed by [reorderStages](https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/stagePlanner.go#L556).
     - [ ] Support bit shift.  
 - [ ] Support variable and accessors.
     - [x] Support `Eval(params)`, `params` is a `map` like `name: object` in `gvaluate `.
     - [x] ~~Basic data type of `params` is `int ,float, string`.~~ Use [json](https://github.com/nlohmann/json) as base data type.
     - [x] Support simple field accessor using json.
-    - [ ] Object data of `params` should reload `operator[]` and `operator` for `access` and compare. Maybe we can accomplish it by define a base object or use template to support accessors.
+    - [x] Object data of `params` should reload `operator[]` and `operator` for `access` and compare. Maybe we can accomplish it by define a base object or use template to support accessors.
 
 - [ ] Add benchmark for Cvaluate.
-
+- [ ] Performance enhancement.
 
 ## Install Cvaluate
 

--- a/cmake/cvaluateConfig.cmake
+++ b/cmake/cvaluateConfig.cmake
@@ -1,7 +1,5 @@
 include(CMakeFindDependencyMacro)
 
-# find_package(json 3.10.1 REQUIRED)
 find_dependency(nlohmann_json)
-# find_dependency(json REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/cvaluateTargets.cmake")

--- a/cmake/modules/FindExtPackages.cmake
+++ b/cmake/modules/FindExtPackages.cmake
@@ -30,5 +30,9 @@ if(CVALUATE_BUILD_TEST)
     # googletest
     # https://github.com/google/googletest
     find_package(googletest 1.11.0 REQUIRED)
-    
+    if(CVALUATE_BUILD_BENCHMARK)
+        # benchmark
+        # https://github.com/google/benchmark
+        find_package(benchmark 1.5.5 REQUIRED)
+    endif()
 endif()

--- a/cvaluate/CMakeLists.txt
+++ b/cvaluate/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 add_library(cvaluate STATIC ${CVALUATE_SOURCE_FILES})
 
-target_precompile_headers(cvaluate PRIVATE ${CVALUATE_INCLUDE_DIR}/pch.h)
+target_precompile_headers(cvaluate PRIVATE ${CVALUATE_INCLUDE_DIR}/cvaluate/pch.h)
 target_include_directories(cvaluate PRIVATE ${CVALUATE_INCLUDE_DIR})
 target_link_libraries(
     cvaluate PRIVATE 

--- a/cvaluate/EvaluableExpression.cpp
+++ b/cvaluate/EvaluableExpression.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 
-#include <EvaluableExpression.h>
-#include <Exception.h>
+#include <cvaluate/EvaluableExpression.h>
+#include <cvaluate/Exception.h>
 
 namespace Cvaluate {
 

--- a/cvaluate/EvaluationStage.cpp
+++ b/cvaluate/EvaluationStage.cpp
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include "./EvaluationStage.h"
-#include "./Exception.h"
+#include <cvaluate/EvaluationStage.h>
+#include <cvaluate/Exception.h>
 
 namespace Cvaluate {
     TokenAvaiableData AddStage(TokenAvaiableData left, TokenAvaiableData right, Parameters) {

--- a/cvaluate/EvaluationStage.cpp
+++ b/cvaluate/EvaluationStage.cpp
@@ -244,31 +244,31 @@ namespace Cvaluate {
         return ret;
     }
 
-    bool IsString(TokenAvaiableData value) {
+    bool IsString(TokenAvaiableData& value) {
         return value.is_string();
     }
 
-    bool IsBool(TokenAvaiableData value) {
+    bool IsBool(TokenAvaiableData& value) {
         return value.is_boolean();
     }
 
-    bool IsNumeric(TokenAvaiableData value) {
+    bool IsNumeric(TokenAvaiableData& value) {
         return IsFloat(value) || IsInt(value);
     }
 
-    bool IsFloat(TokenAvaiableData value) {
+    bool IsFloat(TokenAvaiableData& value) {
         return value.is_number_float();
     }
 
-    bool IsInt(TokenAvaiableData value) {
+    bool IsInt(TokenAvaiableData& value) {
         return value.is_number_integer();
     }
 
-    bool IsArray(TokenAvaiableData value) {
+    bool IsArray(TokenAvaiableData& value) {
         return value.is_object();
     }
 
-    bool AdditionTypeCheck(TokenAvaiableData left, TokenAvaiableData right) {
+    bool AdditionTypeCheck(TokenAvaiableData& left, TokenAvaiableData& right) {
         if (IsNumeric(left) && IsNumeric(right)) {
             return true;
         }
@@ -280,7 +280,7 @@ namespace Cvaluate {
         return true;
     }
 
-    bool ComparatorTypeCheck(TokenAvaiableData left, TokenAvaiableData right) {
+    bool ComparatorTypeCheck(TokenAvaiableData& left, TokenAvaiableData& right) {
         if (IsNumeric(left) && IsNumeric(right)) {
             return true;
         }
@@ -293,7 +293,7 @@ namespace Cvaluate {
     }
 
 
-    bool IsRegexOrString(TokenAvaiableData value) {
+    bool IsRegexOrString(TokenAvaiableData& value) {
         return IsString(value);
     }
 

--- a/cvaluate/OperatorSymbol.cpp
+++ b/cvaluate/OperatorSymbol.cpp
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include <OperatorSymbol.h>
+#include <cvaluate/OperatorSymbol.h>
 
 namespace Cvaluate {
 

--- a/cvaluate/Parsing.cpp
+++ b/cvaluate/Parsing.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 
-#include <Parising.h>
-#include <Exception.h>
+#include <cvaluate/Parising.h>
+#include <cvaluate/Exception.h>
 
 namespace Cvaluate {
     std::vector<ExpressionToken> ParseTokens(std::string& expression, ExpressionFunctionMap& functions) {

--- a/cvaluate/StagePlanner.cpp
+++ b/cvaluate/StagePlanner.cpp
@@ -13,8 +13,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-#include <StagePlanner.h>
-#include <Exception.h>
+#include <cvaluate/StagePlanner.h>
+#include <cvaluate/Exception.h>
 
 namespace Cvaluate {
     std::unordered_map<OperatorSymbol, EvaluationOperator> kStageSymbolMap = {

--- a/cvaluate/Token.cpp
+++ b/cvaluate/Token.cpp
@@ -14,8 +14,8 @@
 * limitations under the License.
 */
 
-#include <Token.h>
-#include <Exception.h>
+#include <cvaluate/Token.h>
+#include <cvaluate/Exception.h>
 
 namespace Cvaluate {
     bool CanTransitionTo(const TokenState& cur_state, const TokenKind& next_kind) {

--- a/cvaluate/pch.cpp
+++ b/cvaluate/pch.cpp
@@ -16,6 +16,6 @@
 
 // pch.cpp: source file corresponding to the pre-compiled header
 
-#include <pch.h>
+#include <cvaluate/pch.h>
 
 // When you are using pre-compiled headers, this source file is necessary for compilation to succeed.

--- a/include/cvaluate/EvaluationStage.h
+++ b/include/cvaluate/EvaluationStage.h
@@ -25,8 +25,8 @@ namespace Cvaluate {
     using Parameters = std::unordered_map<std::string, TokenAvaiableData>;
     // Parameters kEmptyParameters;
     using EvaluationOperator = std::function<TokenAvaiableData(TokenAvaiableData, TokenAvaiableData, Parameters)>;
-    using StageTypeCheck = std::function<bool(TokenAvaiableData)>;
-    using StageCombinedTypeCheck = std::function<bool(TokenAvaiableData, TokenAvaiableData)>;
+    using StageTypeCheck = std::function<bool(TokenAvaiableData&)>;
+    using StageCombinedTypeCheck = std::function<bool(TokenAvaiableData&, TokenAvaiableData&)>;
 
     class EvaluationStage {
         public:
@@ -53,15 +53,15 @@ namespace Cvaluate {
             bool IsShortCircuitable();
     };
 
-    bool IsString(TokenAvaiableData value);
-    bool IsBool(TokenAvaiableData value);
-    bool IsNumeric(TokenAvaiableData value);
-    bool IsFloat(TokenAvaiableData value);
-    bool IsInt(TokenAvaiableData value);
-    bool IsArray(TokenAvaiableData value);
-    bool IsRegexOrString(TokenAvaiableData value);
-    bool AdditionTypeCheck(TokenAvaiableData left, TokenAvaiableData right);
-    bool ComparatorTypeCheck(TokenAvaiableData left, TokenAvaiableData right);
+    bool IsString(TokenAvaiableData& value);
+    bool IsBool(TokenAvaiableData& value);
+    bool IsNumeric(TokenAvaiableData& value);
+    bool IsFloat(TokenAvaiableData& value);
+    bool IsInt(TokenAvaiableData& value);
+    bool IsArray(TokenAvaiableData& value);
+    bool IsRegexOrString(TokenAvaiableData& value);
+    bool AdditionTypeCheck(TokenAvaiableData& left, TokenAvaiableData& right);
+    bool ComparatorTypeCheck(TokenAvaiableData& left, TokenAvaiableData& right);
 
     // Operator type
     TokenAvaiableData AddStage(TokenAvaiableData, TokenAvaiableData, Parameters = {});

--- a/include/cvaluate/Parising.h
+++ b/include/cvaluate/Parising.h
@@ -26,8 +26,8 @@ namespace Cvaluate {
     
     ExpressionToken Readtoken(std::stringstream& stream, TokenState& state, ExpressionFunctionMap functions);
     std::string ReadTokenUntilFalse(std::stringstream& stream, std::function<bool(char character)> condition);
-    std::pair<std::string, bool> ReadUntilFalse(std::stringstream& stream, bool include_white_space, bool break_white_space, 
-            bool allow_escaping, std::function<bool(char character)> condition);
+    std::string ReadUntilFalse(std::stringstream& stream, bool include_white_space, bool break_white_space, 
+            bool allow_escaping, std::function<bool(char character)> condition, bool& conditioned);
 
     std::vector<std::string> Split(std::string str, const std::string& del, int limit);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,3 +42,9 @@ if (CVALUATE_BUILD_TEST)
     gtest_discover_tests(cvaluate_test)
 
 endif()
+
+if(CVALUATE_BUILD_BENCHMARK)
+  add_subdirectory(benchmarks)
+endif()
+
+add_subdirectory(profiling)

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -1,0 +1,39 @@
+#  Copyright 2021 The casbin Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# add_definitions(-DCASBIN_PROJECT_DIR=${CMAKE_SOURCE_DIR})
+
+set(CVALUATE_BENCHMARK_SOURCE
+    main.cpp
+    cvaluate_benchmark.cpp
+)
+
+add_executable(cvaluate_benchmark ${CVALUATE_BENCHMARK_SOURCE})
+
+target_include_directories(cvaluate_benchmark PUBLIC ${CVALUATE_INCLUDE_DIR})
+
+if(UNIX)
+    set_target_properties(cvaluate_benchmark PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+endif()
+
+target_link_libraries(
+    cvaluate_benchmark
+        PRIVATE
+    benchmark
+    cvaluate
+    nlohmann_json::nlohmann_json
+    pthread
+)

--- a/tests/benchmarks/cvaluate_benchmark.cpp
+++ b/tests/benchmarks/cvaluate_benchmark.cpp
@@ -1,0 +1,142 @@
+/*
+* Copyright 2021 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* This is a test file for benchmarking the performance of casbin::Model
+*/
+
+#include <benchmark/benchmark.h>
+#include <cvaluate/cvaluate.h>
+#include "../test_config.h"
+
+static void BenchmarkSingleParse(benchmark::State& state) {
+    for(auto _ : state)
+        Cvaluate::EvaluableExpression("1");
+}
+
+BENCHMARK(BenchmarkSingleParse);
+
+static void BenchmarkSimpleParse(benchmark::State& state) {
+    for(auto _ : state)
+        Cvaluate::EvaluableExpression("(requests_made * requests_succeeded / 100) >= 90");
+}
+
+BENCHMARK(BenchmarkSimpleParse);
+
+static void BenchmarkFullParse(benchmark::State& state) {
+    std::string expression = std::string("2 > 1 &&") +
+		"\'something\' != \'nothing\' || " +
+		"[escapedVariable name with spaces] <= unescaped\\-variableName &&" +
+		"modifierTest + 1000 / 2 > (80 * 100 % 2)";
+    for(auto _ : state)
+        auto x = Cvaluate::EvaluableExpression(expression);
+}
+
+BENCHMARK(BenchmarkFullParse);
+
+static void BenchmarkEvaluationSingle(benchmark::State& state) {
+    auto expression = Cvaluate::EvaluableExpression("1");
+    for(auto _ : state)
+        expression.Evaluate();
+}
+
+BENCHMARK(BenchmarkEvaluationSingle);
+
+static void BenchmarkEvaluationNumericLiteral(benchmark::State& state) {
+    auto expression = Cvaluate::EvaluableExpression("(2) > (1)");
+    for(auto _ : state)
+        expression.Evaluate();
+}
+
+BENCHMARK(BenchmarkEvaluationNumericLiteral);
+
+static void BenchmarkEvaluationLiteralModifiers(benchmark::State& state) {
+    auto expression = Cvaluate::EvaluableExpression("(2) + (2) == (4)");
+    for(auto _ : state)
+        expression.Evaluate();
+}
+
+BENCHMARK(BenchmarkEvaluationLiteralModifiers);
+
+static void BenchmarkEvaluationParameter(benchmark::State& state) {
+    auto expression = Cvaluate::EvaluableExpression("requests_made");
+    auto parameters = Cvaluate::Parameters({
+        {"requests_made", float(99.0)},
+    });
+    for(auto _ : state)
+        expression.Evaluate(parameters);
+}
+
+BENCHMARK(BenchmarkEvaluationParameter);
+
+static void BenchmarkEvaluationParameters(benchmark::State& state) {
+    auto expression = Cvaluate::EvaluableExpression("requests_made > requests_succeeded");
+    auto parameters = Cvaluate::Parameters({
+        {"requests_made", float(99.0)},
+        {"requests_succeeded", float(90.0)},
+    });
+    for(auto _ : state)
+        expression.Evaluate(parameters);
+}
+
+BENCHMARK(BenchmarkEvaluationParameters);
+
+static void BenchmarkEvaluationParametersModifiers(benchmark::State& state) {
+    auto expression = Cvaluate::EvaluableExpression("(requests_made * requests_succeeded / 100) >= 90");
+    auto parameters = Cvaluate::Parameters({
+        {"requests_made", float(99.0)},
+        {"requests_succeeded", float(90.0)},
+    });
+    for(auto _ : state)
+        expression.Evaluate(parameters);
+}
+
+BENCHMARK(BenchmarkEvaluationParametersModifiers);
+
+// static void BenchmarkComplexExpression(benchmark::State& state) {
+//     std::string expressionString = std::string("2 > 1 &&") +
+// 		"'something' != 'nothing' || " +
+// 		"[escapedVariable name with spaces] <= unescaped\\-variableName &&" +
+// 		"modifierTest + 1000 / 2 > (80 * 100 % 2)";
+//     auto expression = Cvaluate::EvaluableExpression(expressionString);
+//     auto parameters = Cvaluate::Parameters({
+//         {"escapedVariable name with spaces", float(99.0)},
+//         {"unescaped\\-variableName", float(90.0)},
+//         {"modifierTest", float(5.0)},
+//     });
+//     for(auto _ : state)
+//         expression.Evaluate(parameters);
+// }
+
+// BENCHMARK(BenchmarkComplexExpression);
+
+static void BenchmarkAccessors(benchmark::State& state) {
+    std::string expression_string = "foo.Int";
+    auto expression = Cvaluate::EvaluableExpression(expression_string);
+    auto parameters = fooParameter;
+    for(auto _ : state)
+        expression.Evaluate(parameters);
+}
+
+BENCHMARK(BenchmarkAccessors);
+
+static void BenchmarkNestedAccessors(benchmark::State& state) {
+    std::string expression_string = "foo.Nested.Funk";
+    auto expression = Cvaluate::EvaluableExpression(expression_string);
+    auto parameters = fooParameter;
+    for(auto _ : state)
+        expression.Evaluate(parameters);
+}
+
+BENCHMARK(BenchmarkNestedAccessors);

--- a/tests/benchmarks/main.cpp
+++ b/tests/benchmarks/main.cpp
@@ -1,0 +1,21 @@
+/*
+* Copyright 2021 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* This is the main file that provides entry point to the entire benchmarking workflow
+*/
+
+#include <benchmark/benchmark.h>
+
+BENCHMARK_MAIN();

--- a/tests/evaluation_test.cpp
+++ b/tests/evaluation_test.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 #include <gtest/gtest.h>
-#include <EvaluableExpression.h>
+#include <cvaluate/EvaluableExpression.h>
 #include "./test_config.h"
 
 namespace {

--- a/tests/evaluation_test.cpp
+++ b/tests/evaluation_test.cpp
@@ -15,6 +15,7 @@
 */
 #include <gtest/gtest.h>
 #include <EvaluableExpression.h>
+#include "./test_config.h"
 
 namespace {
 
@@ -34,21 +35,6 @@ struct TokenEvaluationTest {
         Cvaluate::ExpressionFunctionMap functions = {},
         Cvaluate::Parameters parameters = {}
     ) : Name(name), Input(input), Expected(expected), Functions(functions), Parameters(parameters) {};
-};
-
-Cvaluate::TokenAvaiableData dummyParameterInstance = {
-        {"String", "string!"},
-        {"Int", 101},
-        {"BoolFalse", false},
-        {"Nested", 
-            {
-                {"Funk", "funkalicious"},
-            }
-        }
-    };
-
-Cvaluate::Parameters fooParameter = {
-	{"foo", dummyParameterInstance}
 };
 
 void Assert_Value(Cvaluate::TokenAvaiableData& expected, Cvaluate::TokenAvaiableData& actual, TokenEvaluationTest& test_case) {

--- a/tests/parsing_test.cpp
+++ b/tests/parsing_test.cpp
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 #include <gtest/gtest.h>
-#include <EvaluableExpression.h>
+#include <cvaluate/EvaluableExpression.h>
 
 namespace {
 

--- a/tests/profiling/CMakeLists.txt
+++ b/tests/profiling/CMakeLists.txt
@@ -1,0 +1,40 @@
+#  Copyright 2021 The casbin Authors. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# add_definitions(-DCASBIN_PROJECT_DIR=${CMAKE_SOURCE_DIR})
+
+set(CVALUATE_PROFILE_SOURCE
+    main.cpp
+)
+
+add_definitions(-DSINGLEPARSE)
+
+add_executable(cvaluate_profile ${CVALUATE_PROFILE_SOURCE})
+
+target_include_directories(cvaluate_profile PUBLIC ${CVALUATE_INCLUDE_DIR})
+
+if(UNIX)
+    set_target_properties(cvaluate_profile PROPERTIES
+      POSITION_INDEPENDENT_CODE ON
+    )
+endif()
+
+target_link_libraries(
+    cvaluate_profile
+        PRIVATE
+    benchmark
+    cvaluate
+    nlohmann_json::nlohmann_json
+    pthread
+)

--- a/tests/profiling/main.cpp
+++ b/tests/profiling/main.cpp
@@ -1,0 +1,33 @@
+/*
+* Copyright 2021 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* This is a test file for benchmarking the performance of casbin::Model
+*/
+
+#include <cvaluate/cvaluate.h>
+#include "../test_config.h"
+
+#ifdef SINGLEPARSE
+static void SingleParse(int round) {
+    for(int i = 0; i < round; i++)
+        Cvaluate::EvaluableExpression("1");
+}
+#endif
+
+int main() {
+#ifdef SINGLEPARSE
+    SingleParse(1000);
+#endif
+}

--- a/tests/test_config.h
+++ b/tests/test_config.h
@@ -1,0 +1,37 @@
+/*
+* Copyright 2020 The casbin Authors. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef TEST_CONFIG
+#define TEST_CONFIG
+
+#include <cvaluate/cvaluate.h>
+
+Cvaluate::TokenAvaiableData dummyParameterInstance = {
+        {"String", "string!"},
+        {"Int", 101},
+        {"BoolFalse", false},
+        {"Nested", 
+            {
+                {"Funk", "funkalicious"},
+            }
+        }
+    };
+
+Cvaluate::Parameters fooParameter = {
+	{"foo", dummyParameterInstance}
+};
+
+#endif


### PR DESCRIPTION
<!--
    We follow semantic pull requests. Make sure you sign-off and format every commit message
    as well as the PR title as specified in 
    https://github.com/commitizen/conventional-commit-types/blob/master/index.json

    Eg. feat: New feature name,
    fix: Some error, etc.
-->

## Fixes # <Enter the issue number>

### Description
+ Add benchmark for cvaluate and add a basic profiling framework using macro.


### Screenshots/Testimonials
+ I do the same benchmark as govaluate. And current cvalute isn't as good as govaluate. Then I do simple profiling for cvalute. The main performance loss is due to function handler of different operator.
![3cde2d22dbf362cb05558f728d1dbb0](https://user-images.githubusercontent.com/43725202/150313965-031b9924-fe2f-445c-9d69-0cbe34b49236.png)
![7d6e7759f026555fceec194e02b01b3](https://user-images.githubusercontent.com/43725202/150313992-5dbe36c8-d8a9-4781-8f21-d0f528332c6d.png)
![1642671879(1)](https://user-images.githubusercontent.com/43725202/150313880-8a167a37-3da2-4f52-b060-814a6d6c6726.png)


